### PR TITLE
Proj 244 amo read doesnt reach atomics module

### DIFF
--- a/corev_apu/tb/tb_std_cache_subsystem/hdl/tb_ace_ccu_pkg.sv
+++ b/corev_apu/tb/tb_std_cache_subsystem/hdl/tb_ace_ccu_pkg.sv
@@ -514,6 +514,7 @@ package tb_ace_ccu_pkg;
     task automatic monitor_snoop_cr(input int unsigned i);
       exp_ax_t      exp_aw;
       master_exp_t  exp_b;
+      slv_axi_id_t  exp_aw_id;
       if (slaves_snoop[i].cr_valid && slaves_snoop[i].cr_ready) begin
         WB_Queue_Reset  = 'b0;
         $display("%0tns > Got Response from SNOOP %0d: CR_RESP %b: ",
@@ -525,6 +526,11 @@ package tb_ace_ccu_pkg;
           if(slaves_snoop[i].cr_resp[0] && !slaves_snoop[i].cr_resp[1] && slaves_snoop[i].cr_resp[2]) begin
             // extract write back transaction from WB queues that will pushed into the expected AW queue
             exp_aw = this.write_back_queue_ax[i].pop_front();
+
+            // modify the ID to originate from the responding snoop slave
+            exp_aw_id = {idx_mst_t'(i), exp_aw.slv_axi_id[AxiIdWidthMasters-1:0]};
+            exp_aw.slv_axi_id = exp_aw_id;
+
             this.exp_aw_queue[0].push_front(exp_aw.slv_axi_id, exp_aw);
             $fdisplay(FDCI,"%0tns > Write back occured", $time);
             $fdisplay(FDCI, "\t \t AXI ID: %b, Address: %h", exp_aw.slv_axi_id, exp_aw.slv_axi_addr);

--- a/vendor/planv/ace/src/ace_ccu_top.sv
+++ b/vendor/planv/ace/src/ace_ccu_top.sv
@@ -198,11 +198,12 @@ axi_mux #(
 
 ccu_fsm
 #(
-    .NoMstPorts      ( Cfg.NoSlvPorts     ),
-    .mst_req_t       ( mst_stg_req_t      ),
-    .mst_resp_t      ( mst_stg_resp_t     ),
-    .snoop_req_t     ( snoop_req_t        ),
-    .snoop_resp_t    ( snoop_resp_t       )
+    .NoMstPorts      ( Cfg.NoSlvPorts         ),
+    .SlvAxiIDWidth   ( Cfg.AxiIdWidthSlvPorts ), // ID width of the slave ports
+    .mst_req_t       ( mst_stg_req_t          ),
+    .mst_resp_t      ( mst_stg_resp_t         ),
+    .snoop_req_t     ( snoop_req_t            ),
+    .snoop_resp_t    ( snoop_resp_t           )
 
 ) fsm (
     .clk_i,

--- a/vendor/planv/ace/src/ccu_fsm.sv
+++ b/vendor/planv/ace/src/ccu_fsm.sv
@@ -160,7 +160,7 @@ module ccu_fsm
 
         WAIT_INVALID_R: begin
             // wait for all snoop masters to assert CR valid
-            if ((cr_valid == '1) && (ccu_req_i.r_ready )) begin
+            if ((cr_valid == '1) && (ccu_req_i.r_ready || ccu_req_holder.ar.lock)) begin
                 if(|(data_available & ~response_error)) begin
                     state_d = SEND_AXI_REQ_WRITE_BACK_R;
                 end else begin

--- a/vendor/planv_ace.lock.hjson
+++ b/vendor/planv_ace.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/planvtech/ace.git
-    rev: 879753acaf7dcc94148aa3dab47ade6a6b3430cf
+    rev: a9863d248f83afb0515de10d4a30022e87bcbcfd
   }
 }

--- a/vendor/planv_ace.lock.hjson
+++ b/vendor/planv_ace.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/planvtech/ace.git
-    rev: a9863d248f83afb0515de10d4a30022e87bcbcfd
+    rev: 6f026383da6f89a77c629d15298041162cb53530
   }
 }

--- a/vendor/planv_ace.vendor.hjson
+++ b/vendor/planv_ace.vendor.hjson
@@ -35,5 +35,6 @@
         "scripts",
         "src_files.yml",
         "test",
+        "Makefile",
     ]
 }

--- a/vendor/planv_ace.vendor.hjson
+++ b/vendor/planv_ace.vendor.hjson
@@ -15,7 +15,7 @@
         // URL
         url: "https://github.com/planvtech/ace.git",
         // revision
-        rev: "v0.0.2-pulp",
+        rev: "v0.0.3-pulp",
     }
 
     // Patch dir for local changes


### PR DESCRIPTION
 - The CCU FSM now sends a CleanInvalid to invalidate (and write back)
   any cached (possibly dirty) entry matching an incoming AMO read
   request.

 - The AXI ID for write-back transactions is updated to contain the ID
   of the CPU that had the data.

This commit resolves Jira issue PROJ-244