### PR TITLE
Proj 241 dont invalidate cache before amo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/lowRISC/ariane-ethernet.git
 [submodule "corev_apu/src/axi_riscv_atomics"]
 	path = corev_apu/src/axi_riscv_atomics
-	url = https://github.com/pulp-platform/axi_riscv_atomics.git
+	url = git@github.com:planvtech/axi_riscv_atomics.git
 [submodule "corev_apu/riscv-dbg"]
 	path = corev_apu/riscv-dbg
 	url = https://github.com/pulp-platform/riscv-dbg.git

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -34,6 +34,8 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
     input  logic                                        busy_i,       // dcache is busy with something
     input  logic                                        init_ni,      // do not init after reset
     output logic                                        flushing_o,
+    output logic                                        serving_amo_o,
+    output logic [63:0]                                 serving_amo_addr_o,
     output logic                                        updating_cache_o,
     // Bypass or miss
     input  logic [NR_PORTS-1:0][$bits(miss_req_t)-1:0]  miss_req_i,
@@ -90,9 +92,12 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         MISS_REPL,          // 9
         SAVE_CACHELINE,     // A
         INIT,               // B
-        AMO_REQ,            // C
-        AMO_WAIT_RESP,      // D
-        SEND_CLEAN          // E
+        AMO_WB_REQ,         // C
+        AMO_WB,             // D
+        AMO_REQ,            // E
+        WB_CACHELINE_AMO,   // F
+        AMO_WAIT_RESP,      // 10
+        SEND_CLEAN          // 11
     } state_d, state_q;
 
     // Registers
@@ -164,6 +169,9 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         logic [63:3] address;
         logic        valid;
     } reservation_d, reservation_q;
+
+    assign serving_amo_o = serve_amo_q;
+    assign serving_amo_addr_o = amo_req_i.operand_a;
 
     // ------------------------------
     // Cache Management
@@ -238,7 +246,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
                 colliding_clean_d = '0;
                 // lowest priority are AMOs, wait until everything else is served before going for the AMOs
                 if (amo_req_i.req && !busy_i) begin
-                    state_d = FLUSH_REQ_STATUS;
+                    state_d = AMO_WB_REQ;
                     cnt_d = '0;
                     // remember that flush was started by AMO
                     serve_amo_d = 1'b1;
@@ -379,7 +387,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
             // Write Back Operation
             // ------------------------------
             // ~> evict a cache line from way saved in evict_way_q
-            WB_CACHELINE_FLUSH, WB_CACHELINE_MISS: begin
+            WB_CACHELINE_FLUSH, WB_CACHELINE_MISS, WB_CACHELINE_AMO: begin
 
                 req_fsm_miss_valid  = 1'b1;
                 req_fsm_miss_addr   = {evict_cl_q.tag, cnt_q[DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET], {{DCACHE_BYTE_OFFSET}{1'b0}}};
@@ -401,6 +409,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
                     // go back to handling the miss or flushing or go to idle, depending on where we came from
                     state_d = (state_q == WB_CACHELINE_MISS) ? MISS :
                               (state_q == WB_CACHELINE_FLUSH) ? FLUSH_REQ_STATUS :
+                              (state_q == WB_CACHELINE_AMO) ? AMO_REQ :
                               IDLE;
                 end
             end
@@ -490,8 +499,36 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
             // ----------------------
             // AMOs
             // ----------------------
+            AMO_WB_REQ: begin
+                req_o   = '1;
+                addr_o  = amo_req_i.operand_a;
+                state_d = AMO_WB;
+            end
+
+            AMO_WB: begin
+                state_d = AMO_REQ;
+                for (int unsigned i = 0; i < DCACHE_SET_ASSOC; i++) begin
+                    // match dirty line ~> evict
+                    if (data_i[i].valid & data_i[i].dirty & (data_i[i].tag == amo_req_i.operand_a[DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:DCACHE_INDEX_WIDTH])) begin
+                        evict_way_d = 1'b1 << i;
+                        evict_cl_d  = data_i[i];
+                        cnt_d       = amo_req_i.operand_a[DCACHE_INDEX_WIDTH-1:0];
+                        state_d     = WB_CACHELINE_AMO;
+                        break;                           
+                    end
+                    // match line ~> invalidate
+                    else if (data_i[i].valid & (data_i[i].tag == amo_req_i.operand_a[DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:DCACHE_INDEX_WIDTH])) begin
+                        req_o       = 1'b1;
+                        addr_o  = amo_req_i.operand_a;
+                        be_o.vldrty = 1'b1 << i;
+                        we_o        = 1'b1;
+                        break;
+                    end
+                end
+            end
             // ~> we are here because we need to do the AMO, the cache is clean at this point
             AMO_REQ: begin
+                serve_amo_d = 1'b0;
                 amo_bypass_req.req     = 1'b1;
                 amo_bypass_req.reqtype = ariane_axi::SINGLE_REQ;
                 amo_bypass_req.amo     = amo_req_i.amo_op;

--- a/core/cache_subsystem/std_nbdcache.sv
+++ b/core/cache_subsystem/std_nbdcache.sv
@@ -83,6 +83,8 @@ import std_cache_pkg::*;
     logic [2:0]                        miss_gnt;
     logic [2:0]                        active_serving;
     logic                              flushing;
+    logic                              serving_amo;
+    logic [63:0]                       serving_amo_addr;
 
     logic [2:0]                        bypass_gnt;
     logic [2:0]                        bypass_valid;
@@ -138,6 +140,8 @@ import std_cache_pkg::*;
         .readshared_done_o    ( readshared_done       ),
         .updating_cache_i     ( |updating_cache       ),
         .flushing_i           ( flushing              ),
+        .amo_valid_i          ( serving_amo           ),
+        .amo_addr_i           ( serving_amo_addr      ),
         .*
     );
 
@@ -216,6 +220,8 @@ import std_cache_pkg::*;
         .mshr_index_matches_o   ( mshr_index_matches   ),
         .active_serving_o       ( active_serving       ),
         .flushing_o             ( flushing             ),
+        .serving_amo_o          ( serving_amo          ),
+        .serving_amo_addr_o     ( serving_amo_addr     ),
         .req_o                  ( req             [0]  ),
         .addr_o                 ( addr            [0]  ),
         .data_i                 ( rdata                ),

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -123,8 +123,8 @@ module controller import ariane_pkg::*; (
 // this is not needed in the case since we
 // have a write-through cache in this case
             if (DCACHE_TYPE == int'(cva6_config_pkg::WB)) begin
-              flush_dcache           = 1'b1;
-              fence_active_d         = 1'b1;
+              flush_dcache           = 1'b0;
+              fence_active_d         = 1'b0;
             end
         end
 
@@ -141,8 +141,8 @@ module controller import ariane_pkg::*; (
 // this is not needed in the case since we
 // have a write-through cache in this case
             if (DCACHE_TYPE == int'(cva6_config_pkg::WB)) begin
-              flush_dcache           = 1'b1;
-              fence_active_d         = 1'b1;
+              flush_dcache           = 1'b0;
+              fence_active_d         = 1'b0;
             end
         end
 

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -123,8 +123,8 @@ module controller import ariane_pkg::*; (
 // this is not needed in the case since we
 // have a write-through cache in this case
             if (DCACHE_TYPE == int'(cva6_config_pkg::WB)) begin
-              flush_dcache           = 1'b0;
-              fence_active_d         = 1'b0;
+              flush_dcache           = 1'b1;
+              fence_active_d         = 1'b1;
             end
         end
 
@@ -141,8 +141,8 @@ module controller import ariane_pkg::*; (
 // this is not needed in the case since we
 // have a write-through cache in this case
             if (DCACHE_TYPE == int'(cva6_config_pkg::WB)) begin
-              flush_dcache           = 1'b0;
-              fence_active_d         = 1'b0;
+              flush_dcache           = 1'b1;
+              fence_active_d         = 1'b1;
             end
         end
 

--- a/corev_apu/tb/tb_std_cache_subsystem/hdl/tb_ace_ccu_pkg.sv
+++ b/corev_apu/tb/tb_std_cache_subsystem/hdl/tb_ace_ccu_pkg.sv
@@ -109,8 +109,8 @@ package tb_ace_ccu_pkg;
     ax_queue_t              exp_aw_queue [NoSlaves-1:0];
     exp_ax_t                write_back_queue_ax[NoMasters-1:0][$];
     snoop_pkg::acsnoop_t    acsnoop_hold[NoMasters-1:0];
-    logic  [63:0]           ac_address_holder[NoMasters-1:0];  
-    logic                   WB_Queue_Reset;   
+    logic  [63:0]           ac_address_holder[NoMasters-1:0];
+    logic                   WB_Queue_Reset;
 
 
     slave_exp_t        exp_w_fifo   [NoSlaves-1:0][$];
@@ -216,7 +216,7 @@ package tb_ace_ccu_pkg;
 
         logic write_no_snoop =   (masters_axi[i].aw_snoop == 'b000) && (masters_axi[i].aw_bar[0] == 'b0) &&
                         ((masters_axi[i].aw_domain == 'b00) || (masters_axi[i].aw_domain == 'b11) );
-        logic snoop_aw_trs = ~(write_back | write_no_snoop);  
+        logic snoop_aw_trs = ~(write_back | write_no_snoop);
 
         to_slave_idx = '0;
         decerr = 1'b0;
@@ -227,7 +227,7 @@ package tb_ace_ccu_pkg;
                    slv_axi_addr: masters_axi[i].aw_addr,
                    slv_axi_len:  masters_axi[i].aw_len   };
         this.exp_aw_queue[to_slave_idx].push(exp_aw_id, exp_aw);
-        
+
         // push in write back queue in case of snoop transaction type
         if(snoop_aw_trs == 'b1) begin
           // writeback is always full cache line
@@ -236,10 +236,10 @@ package tb_ace_ccu_pkg;
           $fdisplay(FDCI, "%0tns > WRITE CLEAN INVALID initiated AXI ID: %b, Address: %h",
           $time, exp_aw.slv_axi_id, exp_aw.slv_axi_addr);
           for(int j = 0; j < NoMasters; j++) begin
-            this.write_back_queue_ax[j].push_back( exp_aw); 
+            this.write_back_queue_ax[j].push_back( exp_aw);
           end
         end
-        
+
 
         incr_expected_tests(3);
         $display("%0tns > Master %0d: AW to Slave %0d: Axi ID: %b %x",
@@ -285,13 +285,13 @@ package tb_ace_ccu_pkg;
            slv_axi_id_t tmp;
            tmp = {slaves_axi[i].aw_id[AxiIdWidthSlaves-1:AxiIdWidthSlaves-$clog2(NoMasters+1)], slaves_axi[i].aw_id[AxiIdWidthMasters-1:0]};
            exp_aw = this.exp_aw_queue[i].pop_id(tmp);
-           exp_aw_id = {exp_aw.slv_axi_id[$clog2(NoMasters)+AxiIdWidthMasters-1:AxiIdWidthMasters], idx_mst_t'(0), exp_aw.slv_axi_id[AxiIdWidthMasters-1:0]};
+           exp_aw_id = {{2{exp_aw.slv_axi_id[$clog2(NoMasters)+AxiIdWidthMasters-1:AxiIdWidthMasters]}}, exp_aw.slv_axi_id[AxiIdWidthMasters-1:0]};
         end
         $display("%0tns > Slave  %0d: AW Axi ID: %b",
             $time, i, slaves_axi[i].aw_id);
         if (exp_aw_id != slaves_axi[i].aw_id) begin
           incr_failed_tests(1);
-           $warning("Slave %0d: Unexpected AW with ID: %b", i, slaves_axi[i].aw_id);
+           $warning("Slave %0d: Unexpected AW with ID: %b (exp: %b)", i, slaves_axi[i].aw_id, exp_aw_id);
         end
         if (exp_aw.slv_axi_addr != slaves_axi[i].aw_addr) begin
           incr_failed_tests(1);
@@ -493,10 +493,10 @@ package tb_ace_ccu_pkg;
         $display("%0tns > SNOOP %0d: AC_SNOOP %b: ",
               $time, i, slaves_snoop[i].ac_snoop);
         ac_address_holder[i] = slaves_snoop[i].ac_addr;
-        acsnoop_hold[i]      = slaves_snoop[i].ac_snoop;      
+        acsnoop_hold[i]      = slaves_snoop[i].ac_snoop;
       end
-      if(slaves_snoop[i].ac_snoop == snoop_pkg::CLEAN_INVALID && i == (NoMasters-1)) begin  
-        incr_expected_tests(1); 
+      if(slaves_snoop[i].ac_snoop == snoop_pkg::CLEAN_INVALID && i == (NoMasters-1)) begin
+        incr_expected_tests(1);
         // empty the write back queue of initiator
         cnt_sem.get();
           for (int j = 0; j < NoMasters; j++) begin
@@ -505,7 +505,7 @@ package tb_ace_ccu_pkg;
               WB_Queue_Reset  = 'b1;
             end
           end
-        cnt_sem.put();  
+        cnt_sem.put();
 
       end
     endtask:monitor_snoop_ac
@@ -518,7 +518,7 @@ package tb_ace_ccu_pkg;
       if (slaves_snoop[i].cr_valid && slaves_snoop[i].cr_ready) begin
         WB_Queue_Reset  = 'b0;
         $display("%0tns > Got Response from SNOOP %0d: CR_RESP %b: ",
-              $time, i, slaves_snoop[i].cr_resp);      
+              $time, i, slaves_snoop[i].cr_resp);
         if(slaves_snoop[i].cr_resp[0] && !slaves_snoop[i].cr_resp[1] && !slaves_snoop[i].cr_resp[2]) begin
           incr_conducted_tests(1);
         end
@@ -536,7 +536,7 @@ package tb_ace_ccu_pkg;
             $fdisplay(FDCI, "\t \t AXI ID: %b, Address: %h", exp_aw.slv_axi_id, exp_aw.slv_axi_addr);
             $fdisplay(FDCI, "\t \t AC Address: %h", ac_address_holder[i]);
             incr_conducted_tests(3);
-          end 
+          end
           else begin
               // extract write back transaction from WB queues that will not be processed
               exp_aw = this.write_back_queue_ax[i].pop_front();
@@ -553,7 +553,7 @@ package tb_ace_ccu_pkg;
     task automatic monitor_snoop_cd(input int unsigned i);
       if (slaves_snoop[i].cd_valid && slaves_snoop[i].cd_ready) begin
         $display("%0tns > Got Data from SNOOP %0d: with last flag %b: ",
-              $time, i, slaves_snoop[i].cd_last);    
+              $time, i, slaves_snoop[i].cd_last);
               incr_conducted_tests(1);
       end
     endtask:monitor_snoop_cd
@@ -589,7 +589,7 @@ package tb_ace_ccu_pkg;
       if(FDCI)
         $display("Clean inavlid log file created ");
       else
-        $fatal("Clean inavlid log file Failed"); 
+        $fatal("Clean inavlid log file Failed");
 
       Continous: fork
         begin

--- a/corev_apu/tb/tb_std_cache_subsystem/hdl/tb_std_cache_subsystem_pkg.sv
+++ b/corev_apu/tb/tb_std_cache_subsystem/hdl/tb_std_cache_subsystem_pkg.sv
@@ -1980,6 +1980,88 @@ package tb_std_cache_subsystem_pkg;
 
         endtask
 
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        // check behaviour when invalidating a cacheline
+        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        local task automatic invalidate (input logic[63:0] addr);
+            int w_cnt = 0;
+            for (int l = 0; l < DCACHE_SET_ASSOC; l++) begin
+                int w = addr[DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET];
+                if (cache_status[w][l].valid && cache_status[w][l].dirty && cache_status[w][l].tag == addr[DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:DCACHE_INDEX_WIDTH]) begin
+                    fork
+                        begin
+                            automatic int ll = l;
+                            automatic int ww = w;
+                            // expect write back of dirty data
+                            ax_ace_beat_t aw_beat = new();
+                            b_beat_t      b_beat  = new();
+                            w_beat_t      w_beat  = new();
+
+                            // wait for AW beat
+                            aw_mbx.get(aw_beat);
+                            $display("%t ns %s.invalidate: got AW beat for cache[%0d][%0d]", $time, name, ww, ll);
+                            if (!isWriteBack(aw_beat))
+                                $error("%s.flush_invalidatecache : WRITEBACK request expected after eviction of cache[%0d][%0d]", name, ww, ll);
+                            a_empty_aw : assert (aw_mbx.num() == 0) else $error ("%S.invalidate : AW mailbox not empty", name);
+
+                            // wait for W beat
+                            while (!w_beat.w_last) begin
+                                w_mbx.get(w_beat);
+                                $display("%t ns %s.invalidate: got W beat with last = %0d for cache[%0d][%0d]", $time, name, w_beat.w_last, ww, ll);
+                            end
+                            a_empty_w : assert (w_mbx.num() == 0) else $error ("%S.invalidate : W mailbox not empty", name);
+
+                            // wait for B beat
+                            b_mbx.get(b_beat);
+                            $display("%t ns %s.invalidate: got B beat for cache[%0d][%0d]", $time, name, ww, ll);
+                            a_empty_b : assert (b_mbx.num() == 0) else $error ("%S.invalidate : B mailbox not empty", name);
+                        end
+                        begin
+                            // expect clear of cache entry
+                            automatic int ll  = l;
+                            automatic int ww  = w;
+                            automatic int cnt = 0;
+                            while (!gnt_vif.gnt[0]) begin
+                                $display("%t ns %s.invalidate : skipping cycle without grant for evict of cache entry [%0d][%0d]", $time, name, ww, ll);
+                                @(posedge sram_vif.clk); // skip cycles without grant
+                                cnt++;
+                                if (cnt > 1000) begin
+                                    $error("%s.invalidate : timeout while waiting for grant for evict of cache entry [%0d][%0d]", name, ww, ll);
+                                    break;
+                                end
+                            end
+                            @(posedge sram_vif.clk);
+
+                            // clear entry in cache model
+                            $display("%t ns %s.invalidate: Evicting cache entry [%0d][%0d]", $time, name, ww, ll);
+                            cache_status[ww][ll] = '0;
+                        end
+                    join_any
+
+                    break;
+                end
+                else if (cache_status[w][l].valid && cache_status[w][l].tag == addr[DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:DCACHE_INDEX_WIDTH]) begin
+                    // expect clear of cache entry
+                    while (!gnt_vif.gnt[0]) begin
+                        $display("%t ns %s.invalidate : skipping cycle without grant for clear of cache entry [%0d][%0d]", $time, name, w, l);
+                        @(posedge sram_vif.clk); // skip cycles without grant
+                        w_cnt++;
+                        if (w_cnt > 1000) begin
+                            $error("%s.invalidate : timeout while waiting for grant for clear of cache entry [%0d][%0d]", name, w, l);
+                            break;
+                        end
+                    end
+                    @(posedge sram_vif.clk);
+
+                    // clear entry in cache model
+                    $display("%t ns %s.invalidate: Evicting cache entry [%0d][%0d]", $time, name, w, l);
+                    cache_status[w][l] = '0;
+
+                    break;
+
+                end
+            end
+        endtask
 
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         // check behaviour when receiving AMO requests
@@ -1995,7 +2077,7 @@ package tb_std_cache_subsystem_pkg;
 
                 fork
                     begin
-                        flush_cache();
+                        invalidate(msg.addr);
                         if (msg.op != AMO_LR) begin
                             ax_ace_beat_t aw_beat     = new();
                             b_beat_t      b_beat      = new();

--- a/vendor/planv/ace/src/ace_ccu_top.sv
+++ b/vendor/planv/ace/src/ace_ccu_top.sv
@@ -58,6 +58,7 @@ slv_resp_t [Cfg.NoSlvPorts-1:0] [1:0]      slv_resps;
 // signals into the ace_muxes
 mst_stg_req_t  [Cfg.NoSlvPorts:0]          mst_reqs;   // one extra port for CCU
 mst_stg_resp_t [Cfg.NoSlvPorts:0]          mst_resps;
+mst_stg_req_t  [Cfg.NoSlvPorts-1:0]          mst_reqs_tmp;
 // signals into the CCU
 slv_req_t  [Cfg.NoSlvPorts-1:0]            ccu_reqs_i;
 slv_resp_t [Cfg.NoSlvPorts-1:0]            ccu_resps_o;
@@ -152,8 +153,14 @@ axi_mux #(
 
 // connection reqs and resps for non-shareable tarnsactions with axi_mux
 for (genvar i = 0; i < Cfg.NoSlvPorts; i++) begin : gen_non_shared_conn
-    `ACE_ASSIGN_REQ_STRUCT(mst_reqs[i], slv_reqs[i][0])
+    `ACE_ASSIGN_REQ_STRUCT(mst_reqs_tmp[i], slv_reqs[i][0])
     `ACE_ASSIGN_RESP_STRUCT(slv_resps[i][0], mst_resps[i])
+
+  always_comb begin
+    mst_reqs[i] = mst_reqs_tmp[i];
+    mst_reqs[i].aw.id[Cfg.AxiIdWidthSlvPorts +: $clog2(Cfg.NoSlvPorts)] = i[$clog2(Cfg.NoSlvPorts)-1:0];
+    mst_reqs[i].ar.id[Cfg.AxiIdWidthSlvPorts +: $clog2(Cfg.NoSlvPorts)] = i[$clog2(Cfg.NoSlvPorts)-1:0];
+  end
 end
 
 // connection reqs and resps for shareable transactions with CCU

--- a/vendor/planv_ace.lock.hjson
+++ b/vendor/planv_ace.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/planvtech/ace.git
-    rev: 6f026383da6f89a77c629d15298041162cb53530
+    rev: 7f23fdc795159bd6c0b3607f9e990d435180c1d7
   }
 }

--- a/vendor/planv_ace.vendor.hjson
+++ b/vendor/planv_ace.vendor.hjson
@@ -15,7 +15,7 @@
         // URL
         url: "https://github.com/planvtech/ace.git",
         // revision
-        rev: "v0.0.3-pulp",
+        rev: "7f23fdc795159bd6c0b3607f9e990d435180c1d7",
     }
 
     // Patch dir for local changes


### PR DESCRIPTION
This branch contains the changes in branch `PROJ-240_no_cache_flush` but with flush re-enabled on FENCE instructions.
It also contains a fix of bug PROJ-245 from the branch `PROJ-245_reduce_ID_for_multicore`.