### PR TITLE
Proj 258 unit tests support parallel cache requests

### DIFF
--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -92,7 +92,8 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         INIT,               // B
         AMO_REQ,            // C
         AMO_WAIT_RESP,      // D
-        SEND_CLEAN          // E
+        SEND_CLEAN,         // E
+        REQ_CACHELINE_UNIQUE // F
     } state_d, state_q;
 
     // Registers
@@ -100,8 +101,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
     logic [DCACHE_INDEX_WIDTH-1:0]          cnt_d, cnt_q;
     logic [DCACHE_SET_ASSOC-1:0]            evict_way_d, evict_way_q;
 
-    logic                                   colliding_clean_d, colliding_clean_q;
-    logic                                   req_unique_d, req_unique_q;
+    logic [NR_PORTS-1:0]                    colliding_clean_d, colliding_clean_q;
 
     // cache line to evict
     cache_line_t                            evict_cl_d, evict_cl_q;
@@ -226,7 +226,6 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         evict_cl_d   = evict_cl_q;
         mshr_d       = mshr_q;
         colliding_clean_d = colliding_clean_q;
-        req_unique_d      = req_unique_q;
         // communicate to the requester which unit we are currently serving
         active_serving_o[mshr_q.id] = mshr_q.valid;
         // AMOs
@@ -235,21 +234,10 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         amo_operand_b = '0;
 
         // Detect if a MAKE_UNIQUE request collides with an invalidation from snoop
-        // NOTE: the code below will not work if multiple cache controllers are requesting MAKE_UNIQUE. Currently this
-        // is not the case, add assertion to catch any change.
-        // pragma translate_off
-        a_make_unique_onehot : assert #0 ($onehot0(miss_req_make_unique)) else
-            $error("Multiple MAKE_UNIQUE requests not supported");
-        // pragma translate_on
         for (int unsigned i = 0; i < NR_PORTS; i++) begin
-            if (snoop_invalidate_i && miss_req_valid[i] && miss_req_make_unique[i] && !colliding_clean_q) begin
-                colliding_clean_d = (snoop_invalidate_addr_i[DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET] ==
-                                     miss_req_addr[i][DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET]);
-                // it is assumed that only cache_ctrl[2] (write) will do a make_unique request
-                // pragma translate_off
-                a_make_unique_write_only : assert #0 (i==2) else
-                    $error("MAKE_UNIQUE requests only expected from cache_ctrl 2");
-                // pragma translate_on
+            if (snoop_invalidate_i && miss_req_valid[i] && miss_req_make_unique[i] && !colliding_clean_q[i]) begin
+                colliding_clean_d[i] = (snoop_invalidate_addr_i[DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET] ==
+                                        miss_req_addr[i][DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:DCACHE_BYTE_OFFSET]);
             end
         end
 
@@ -327,46 +315,46 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
                         cnt_d = mshr_q.addr[DCACHE_INDEX_WIDTH-1:0];
                     // no - we can request a cache line now
                     end else begin
-                        state_d = REQ_CACHELINE;
-                        if (colliding_clean_q && (mshr_q.id == 2)) begin
-                            // instruct to request unique
-                            req_unique_d = 1'b1;
+                        if (colliding_clean_q[mshr_q.id]) begin
                             // we have now handled the colliding invalidation
-                            colliding_clean_d = 1'b0;
+                            colliding_clean_d[mshr_q.id] = 1'b0;
+                            state_d = REQ_CACHELINE_UNIQUE;
+                        end else begin
+                            state_d = REQ_CACHELINE;
                         end
                     end
                 // we have at least one free way
                 end else begin
                     // get victim cache-line by looking for the first non-valid bit
                     evict_way_d = get_victim_cl(~valid_way);
-                    state_d = REQ_CACHELINE;
-                    if (colliding_clean_q && (mshr_q.id == 2)) begin
-                        // instruct to request unique
-                        req_unique_d = 1'b1;
+                    if (colliding_clean_q[mshr_q.id]) begin
                         // we have now handled the colliding invalidation
-                        colliding_clean_d = 1'b0;
+                        colliding_clean_d[mshr_q.id] = 1'b0;
+                        state_d = REQ_CACHELINE_UNIQUE;
+                    end else begin
+                        state_d = REQ_CACHELINE;
                     end
                 end
             end
 
             // ~> we can just load the cache-line, the way is stored in evict_way_q
-            REQ_CACHELINE: begin
+            REQ_CACHELINE, REQ_CACHELINE_UNIQUE : begin
                 req_fsm_miss_valid  = 1'b1;
                 req_fsm_miss_addr   = mshr_q.addr;
-                case ({mshr_q.we, is_inside_shareable_regions(ArianeCfg, mshr_q.addr)})
-                    2'b00: req_fsm_miss_type = ariane_ace::READ_NO_SNOOP;
-                    2'b01: req_fsm_miss_type = ariane_ace::READ_SHARED;
-                    2'b10: req_fsm_miss_type = ariane_ace::READ_NO_SNOOP;
-                    2'b11: req_fsm_miss_type = ariane_ace::READ_UNIQUE;
-                endcase
-                // start a ReadUnique also if we reached this state after a colliding invalidation
-                if (req_unique_q)
-                  req_fsm_miss_type = ariane_ace::READ_UNIQUE;
+                if (state_q == REQ_CACHELINE_UNIQUE) begin
+                    // start a ReadUnique request, the requested adress was cleared by snoop
+                    req_fsm_miss_type = ariane_ace::READ_UNIQUE;
+                end else begin
+                    case ({mshr_q.we, is_inside_shareable_regions(ArianeCfg, mshr_q.addr)})
+                        2'b00: req_fsm_miss_type = ariane_ace::READ_NO_SNOOP;
+                        2'b01: req_fsm_miss_type = ariane_ace::READ_SHARED;
+                        2'b10: req_fsm_miss_type = ariane_ace::READ_NO_SNOOP;
+                        2'b11: req_fsm_miss_type = ariane_ace::READ_UNIQUE;
+                    endcase
+                end
                 if (gnt_miss_fsm) begin
                     state_d = SAVE_CACHELINE;
                     miss_gnt_o[mshr_q.id] = 1'b1;
-                    // we have now served the request for unique
-                    req_unique_d = 1'b0;
                 end
             end
 
@@ -621,7 +609,6 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
             evict_cl_q    <= '0;
             serve_amo_q   <= 1'b0;
             colliding_clean_q <= '0;
-            req_unique_q      <= 1'b0;
         end else begin
             mshr_q        <= mshr_d;
             state_q       <= state_d;
@@ -630,7 +617,6 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
             evict_cl_q    <= evict_cl_d;
             serve_amo_q   <= serve_amo_d;
             colliding_clean_q <= colliding_clean_d;
-            req_unique_q      <= req_unique_d;
         end
     end
 

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -98,7 +98,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         AMO_REQ,            // E
         WB_CACHELINE_AMO,   // F
         AMO_WAIT_RESP,      // 10
-        SEND_CLEAN          // 11
+        SEND_CLEAN,         // 11
         REQ_CACHELINE_UNIQUE // 12
     } state_d, state_q;
 

--- a/corev_apu/tb/tb_std_cache_subsystem/hdl/dcache_intf.sv
+++ b/corev_apu/tb/tb_std_cache_subsystem/hdl/dcache_intf.sv
@@ -76,4 +76,5 @@ interface dcache_gnt_if (input logic clk);
     logic [4:0] gnt;
     logic [4:0] rd_gnt;
     logic [2:0] bypass_gnt;
+    logic [2:0] miss_gnt;
 endinterface

--- a/corev_apu/tb/tb_std_cache_subsystem/hdl/tb_std_cache_subsystem_pkg.sv
+++ b/corev_apu/tb/tb_std_cache_subsystem/hdl/tb_std_cache_subsystem_pkg.sv
@@ -1876,11 +1876,17 @@ package tb_std_cache_subsystem_pkg;
                                     $error("%s.check_cache_msg : WRITE_UNIQUE request expected for message : %s", name, msg.print_me());
                             end else begin
                                 ax_ace_beat_t aw_beat = new();
+                                int cnt = 0;
                                 // wait for grant before checking AW, a snoop transaction may be active
                                 while (!gnt_vif.bypass_gnt[msg.port_idx]) begin
-                                    $display("%t ns %s.check_cache_msg: skipping cycle without grant before checking AW for message : %s", $time, name, msg.print_me());
                                     @(posedge sram_vif.clk);
+                                    cnt++;
+                                    if (cnt > cache_msg_timeout) begin
+                                        $error("%s.check_cache_msg : Timeout while waiting for grant before checking AW for message : %s", name, msg.print_me());
+                                        break;
+                                    end
                                 end
+
                                 aw_mbx.get(aw_beat);
                                 $display("%t ns %s.check_cache_msg: got AW beat for message : %s", $time, name, msg.print_me());
                                 if (!isWriteNoSnoop(aw_beat))


### PR DESCRIPTION
RTL updates:
- miss_handler: avoid clearing `colliding_clean` when processing a request from "another" cache controller by having one `colliding_clean` bit per request
- miss_handler: generalize `colliding_clean` handling (no special treatment of requests from cache controller 2)

Testbench updates:
- wait for grant from miss handler before checking AXI transactions
- improved timing of `msg.prio` and `msg.target_way` assignments
- added (even) more printouts