### PR TITLE
Remove custom performance counters

### DIFF
--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -31,7 +31,6 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
     input  logic                                        flush_i,      // flush request
     output logic                                        flush_ack_o,  // acknowledge successful flush
     output logic                                        miss_o,
-    output logic [1:0]                                  miss_id_o,
     input  logic                                        busy_i,       // dcache is busy with something
     input  logic                                        init_ni,      // do not init after reset
     output logic                                        flushing_o,
@@ -235,7 +234,6 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         // core
         flush_ack_o         = 1'b0;
         miss_o              = 1'b0; // to performance counter
-        miss_id_o           = mshr_q.id;  // to performance counter
         serve_amo_d         = serve_amo_q;
         // --------------------------------
         // Flush and Miss operation

--- a/core/cache_subsystem/snoop_cache_ctrl.sv
+++ b/core/cache_subsystem/snoop_cache_ctrl.sv
@@ -44,8 +44,6 @@ module snoop_cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
   input  logic  [DCACHE_INDEX_WIDTH-1:0]     miss_invalidate_addr_i,
 
   //
-  output logic                               clean_invalid_hit_o,  // to performance counter
-  output logic                               clean_invalid_miss_o, // to performance counter
   input  logic                               updating_cache_i,
   output readshared_done_t                   readshared_done_o
 );
@@ -150,9 +148,6 @@ module snoop_cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
     invalidate_o      = 1'b0;
     invalidate_addr_o = {mem_req_q.tag, mem_req_q.index};
 
-    clean_invalid_hit_o = 1'b0;
-    clean_invalid_miss_o = 1'b0;
-
     case (state_q)
 
       IDLE: begin
@@ -216,7 +211,6 @@ module snoop_cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
               cr_resp_d.passDirty = dirty;
               cr_resp_d.isShared = 1'b0;
               state_d = INVALIDATE;
-              clean_invalid_hit_o = 1'b1;
             end
             snoop_pkg::READ_ONCE: begin
               cr_resp_d.isShared = shared;
@@ -241,7 +235,6 @@ module snoop_cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
           cr_resp_d.passDirty = 1'b0;
           cr_resp_d.isShared = 1'b0;
           state_d = SEND_CR_RESP;
-          clean_invalid_miss_o = (ac_snoop_q == snoop_pkg::CLEAN_INVALID);
         end
       end
 

--- a/core/cache_subsystem/std_cache_subsystem.sv
+++ b/core/cache_subsystem/std_cache_subsystem.sv
@@ -51,14 +51,7 @@ module std_cache_subsystem import ariane_pkg::*; import std_cache_pkg::*; #(
     input  logic                           dcache_flush_i,         // high until acknowledged
     output logic                           dcache_flush_ack_o,     // send a single cycle acknowledge signal when the cache is flushed
     output logic                           dcache_miss_o,          // we missed on a ld/st
-    output logic                           dcache_hit_o,           // we hit on a ld/st
-    output logic                           dcache_flushing_o,      // flushing
     output logic                           wbuffer_empty_o,        // statically set to 1, as there is no wbuffer in this cache system
-    output logic                           dcache_write_hit_unique_o,
-    output logic                           dcache_write_hit_shared_o,
-    output logic                           dcache_write_miss_o,
-    output logic                           dcache_clean_invalid_hit_o,
-    output logic                           dcache_clean_invalid_miss_o,
     // Request ports
     input  dcache_req_i_t   [2:0]          dcache_req_ports_i,     // to/from LSU
     output dcache_req_o_t   [2:0]          dcache_req_ports_o,     // to/from LSU
@@ -142,14 +135,7 @@ module std_cache_subsystem import ariane_pkg::*; import std_cache_pkg::*; #(
       .flush_i      ( dcache_flush_i         ),
       .flush_ack_o  ( dcache_flush_ack_o     ),
       .miss_o       ( dcache_miss_o          ),
-      .hit_o        ( dcache_hit_o           ),
-      .flushing_o   ( dcache_flushing_o      ),
       .busy_o       ( dcache_busy            ),
-      .write_hit_unique_o   ( dcache_write_hit_unique_o   ),
-      .write_hit_shared_o   ( dcache_write_hit_shared_o   ),
-      .write_miss_o         ( dcache_write_miss_o         ),
-      .clean_invalid_hit_o  ( dcache_clean_invalid_hit_o  ),
-      .clean_invalid_miss_o ( dcache_clean_invalid_miss_o ),
       .stall_i      ( stall_i                ),
       .init_ni      ( init_ni                ),
       .axi_bypass_o ( axi_req_bypass         ),

--- a/core/cache_subsystem/std_nbdcache.sv
+++ b/core/cache_subsystem/std_nbdcache.sv
@@ -29,13 +29,6 @@ module std_nbdcache import std_cache_pkg::*; import ariane_pkg::*; #(
     input  logic                           flush_i,     // high until acknowledged
     output logic                           flush_ack_o, // send a single cycle acknowledge signal when the cache is flushed
     output logic                           miss_o,      // we missed on a LD/ST
-    output logic                           hit_o,
-    output logic                           write_hit_unique_o,
-    output logic                           write_hit_shared_o,
-    output logic                           write_miss_o,
-    output logic                           clean_invalid_hit_o,
-    output logic                           clean_invalid_miss_o,
-    output logic                           flushing_o,
     output logic                           busy_o,
     input  logic                           stall_i,   // stall new memory requests
     input  logic                           init_ni,
@@ -115,10 +108,6 @@ import std_cache_pkg::*;
     // Busy signals
     logic miss_handler_busy;
 
-    logic [2:0] hit;
-    logic [2:0] uniq;
-    logic [1:00] miss_id;
-
     readshared_done_t readshared_done;
     logic [3:0]       updating_cache;
 
@@ -126,15 +115,6 @@ import std_cache_pkg::*;
     logic [DCACHE_INDEX_WIDTH-1:0]       miss_invalidate_addr;
 
     assign busy_o = |busy | miss_handler_busy;
-
-    assign hit_o = |hit;
-
-    assign flushing_o = flushing;
-
-    assign write_hit_unique_o = hit[2] && uniq[2];
-    assign write_hit_shared_o = hit[2] && !uniq[2];
-    assign write_miss_o = miss_o && (miss_id == 2);
-
 
     // ------------------
     // Cache Controller
@@ -167,12 +147,8 @@ import std_cache_pkg::*;
         .flushing_i           ( flushing              ),
         .amo_valid_i          ( serving_amo           ),
         .amo_addr_i           ( serving_amo_addr      ),
-
         .miss_invalidate_req_i   (miss_invalidate_req  ),
         .miss_invalidate_addr_i  (miss_invalidate_addr ),
-
-        .clean_invalid_hit_o  ( clean_invalid_hit_o   ),
-        .clean_invalid_miss_o ( clean_invalid_miss_o  ),
         .*
     );
 
@@ -183,8 +159,8 @@ import std_cache_pkg::*;
             ) i_cache_ctrl (
                 .bypass_i              ( ~enable_i            ),
                 .busy_o                ( busy            [i]  ),
-                .hit_o                 ( hit             [i-1] ),
-                .unique_o              ( uniq            [i-1] ),
+                .hit_o                 ( /* NC */             ),
+                .unique_o              ( /* NC */             ),
                 .stall_i               ( stall_i | flush_i    ),
                 // from core
                 .req_port_i            ( req_ports_i     [i-1] ),
@@ -268,7 +244,6 @@ import std_cache_pkg::*;
         .axi_data_o,
         .axi_data_i,
         .updating_cache_o       ( updating_cache   [0] ),
-        .miss_id_o              ( miss_id              ),
         .*
     );
 

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -556,36 +556,6 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_MHPM_COUNTER_30,
                 riscv::CSR_MHPM_COUNTER_31 :     csr_rdata   = perf_data_i;
 
-                riscv::CSR_L1_ICACHE_MISS,
-                riscv::CSR_L1_DCACHE_MISS,
-                riscv::CSR_ITLB_MISS     ,
-                riscv::CSR_DTLB_MISS     ,
-                riscv::CSR_LOAD          ,
-                riscv::CSR_STORE         ,
-                riscv::CSR_EXCEPTION     ,
-                riscv::CSR_EXCEPTION_RET ,
-                riscv::CSR_BRANCH_JUMP   ,
-                riscv::CSR_CALL          ,
-                riscv::CSR_RET           ,
-                riscv::CSR_MIS_PREDICT   ,
-                riscv::CSR_SB_FULL       ,
-                riscv::CSR_IF_EMPTY      ,
-                riscv::CSR_HPM_COUNTER_17,
-                riscv::CSR_HPM_COUNTER_18,
-                riscv::CSR_HPM_COUNTER_19,
-                riscv::CSR_HPM_COUNTER_20,
-                riscv::CSR_HPM_COUNTER_21,
-                riscv::CSR_HPM_COUNTER_22,
-                riscv::CSR_HPM_COUNTER_23,
-                riscv::CSR_HPM_COUNTER_24,
-                riscv::CSR_HPM_COUNTER_25,
-                riscv::CSR_HPM_COUNTER_26,
-                riscv::CSR_HPM_COUNTER_27,
-                riscv::CSR_HPM_COUNTER_28,
-                riscv::CSR_HPM_COUNTER_29,
-                riscv::CSR_HPM_COUNTER_30,
-                riscv::CSR_HPM_COUNTER_31 :     csr_rdata   = perf_data_i;
-
                 riscv::CSR_MHPM_COUNTER_3H,
                 riscv::CSR_MHPM_COUNTER_4H,
                 riscv::CSR_MHPM_COUNTER_5H,
@@ -1889,14 +1859,14 @@ module csr_regfile import ariane_pkg::*; #(
                         riscv::PRIV_LVL_M: privilege_violation = 1'b0;
                         riscv::PRIV_LVL_S: begin
                             virtual_privilege_violation = v_q & mcounteren_q[csr_addr_i[4:0]] & ~hcounteren_q[csr_addr_i[4:0]];
-                            privilege_violation = 1'b0; //~mcounteren_q[csr_addr_i[4:0]];
+                            privilege_violation = ~mcounteren_q[csr_addr_i[4:0]];
                         end
                         riscv::PRIV_LVL_U: begin
                             virtual_privilege_violation = v_q & mcounteren_q[csr_addr_i[4:0]] & ~hcounteren_q[csr_addr_i[4:0]];
                             if(v_q) begin
                                 privilege_violation = ~mcounteren_q[csr_addr_i[4:0]] & ~scounteren_q[csr_addr_i[4:0]] & hcounteren_q[csr_addr_i[4:0]];
                             end else begin
-                                privilege_violation = 1'b0; //~mcounteren_q[csr_addr_i[4:0]] & ~scounteren_q[csr_addr_i[4:0]];
+                                privilege_violation = ~mcounteren_q[csr_addr_i[4:0]] & ~scounteren_q[csr_addr_i[4:0]];
                             end
                         end
                     endcase
@@ -1922,8 +1892,8 @@ module csr_regfile import ariane_pkg::*; #(
                 if (csr_addr_i inside {[riscv::CSR_CYCLE:riscv::CSR_HPM_COUNTER_31]}) begin
                     unique case (priv_lvl_o)
                         riscv::PRIV_LVL_M: privilege_violation = 1'b0;
-                        riscv::PRIV_LVL_S: privilege_violation = 1'b0; //~mcounteren_q[csr_addr_i[4:0]];
-                        riscv::PRIV_LVL_U: privilege_violation = 1'b0; //~mcounteren_q[csr_addr_i[4:0]] & ~scounteren_q[csr_addr_i[4:0]];
+                        riscv::PRIV_LVL_S: privilege_violation = ~mcounteren_q[csr_addr_i[4:0]];
+                        riscv::PRIV_LVL_U: privilege_violation = ~mcounteren_q[csr_addr_i[4:0]] & ~scounteren_q[csr_addr_i[4:0]];
                     endcase
                 end
             end

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -237,15 +237,6 @@ module cva6 import ariane_pkg::*; #(
   logic                     itlb_miss_ex_perf;
   logic                     dtlb_miss_ex_perf;
   logic                     dcache_miss_cache_perf;
-  logic                     dcache_hit_cache_perf;
-  logic                     dcache_flushing_cache_perf;
-
-  logic                     dcache_write_hit_unique_cache_perf;
-  logic                     dcache_write_hit_shared_cache_perf;
-  logic                     dcache_write_miss_cache_perf;
-  logic                     dcache_clean_invalid_hit_cache_perf;
-  logic                     dcache_clean_invalid_miss_cache_perf;
-
   logic                     icache_miss_cache_perf;
   logic [NumPorts-1:0][DCACHE_SET_ASSOC-1:0] miss_vld_bits;
   logic                     stall_issue;
@@ -734,43 +725,33 @@ module cva6 import ariane_pkg::*; #(
   // ------------------------
   if (PERF_COUNTER_EN) begin: gen_perf_counter
   perf_counters #(
-    .NumPorts             ( NumPorts                   )
+    .NumPorts            ( NumPorts                  )
   ) perf_counters_i (
-    .clk_i                ( clk_i                      ),
-    .rst_ni               ( rst_ni                     ),
-    .debug_mode_i         ( debug_mode                 ),
-    .addr_i               ( addr_csr_perf              ),
-    .we_i                 ( we_csr_perf                ),
-    .data_i               ( data_csr_perf              ),
-    .data_o               ( data_perf_csr              ),
-    .commit_instr_i       ( commit_instr_id_commit     ),
-    .commit_ack_i         ( commit_ack                 ), 
- 
-    .l1_icache_miss_i     ( icache_miss_cache_perf     ),
-    .l1_dcache_miss_i     ( dcache_miss_cache_perf     ),
-    .l1_dcache_hit_i      ( dcache_hit_cache_perf      ),
-    .l1_dcache_flushing_i ( dcache_flushing_cache_perf ),
+    .clk_i               ( clk_i                     ),
+    .rst_ni              ( rst_ni                    ),
+    .debug_mode_i        ( debug_mode                ),
+    .addr_i              ( addr_csr_perf             ),
+    .we_i                ( we_csr_perf               ),
+    .data_i              ( data_csr_perf             ),
+    .data_o              ( data_perf_csr             ),
+    .commit_instr_i      ( commit_instr_id_commit    ),
+    .commit_ack_i        ( commit_ack                ),
 
-    .l1_dcache_write_hit_unique_i   ( dcache_write_hit_unique_cache_perf   ),
-    .l1_dcache_write_hit_shared_i   ( dcache_write_hit_shared_cache_perf   ),
-    .l1_dcache_write_miss_i         ( dcache_write_miss_cache_perf         ),
-    .l1_dcache_clean_invalid_hit_i  ( dcache_clean_invalid_hit_cache_perf  ),
-    .l1_dcache_clean_invalid_miss_i ( dcache_clean_invalid_miss_cache_perf ),
-
-    .amo_i                ( amo_req.req                ),
-    .itlb_miss_i          ( itlb_miss_ex_perf          ),
-    .dtlb_miss_i          ( dtlb_miss_ex_perf          ),
-    .sb_full_i            ( sb_full                    ),
-    .if_empty_i           ( ~fetch_valid_if_id         ),
-    .ex_i                 ( ex_commit                  ),
-    .eret_i               ( eret                       ),
-    .resolved_branch_i    ( resolved_branch            ),
-    .branch_exceptions_i  ( flu_exception_ex_id        ),
-    .l1_icache_access_i   ( icache_dreq_if_cache       ),
-    .l1_dcache_access_i   ( dcache_req_ports_ex_cache  ),
-    .miss_vld_bits_i      ( miss_vld_bits              ),
-    .i_tlb_flush_i        ( flush_tlb_ctrl_ex          ),
-    .stall_issue_i        ( stall_issue                )
+    .l1_icache_miss_i    ( icache_miss_cache_perf    ),
+    .l1_dcache_miss_i    ( dcache_miss_cache_perf    ),
+    .itlb_miss_i         ( itlb_miss_ex_perf         ),
+    .dtlb_miss_i         ( dtlb_miss_ex_perf         ),
+    .sb_full_i           ( sb_full                   ),
+    .if_empty_i          ( ~fetch_valid_if_id        ),
+    .ex_i                ( ex_commit                 ),
+    .eret_i              ( eret                      ),
+    .resolved_branch_i   ( resolved_branch           ),
+    .branch_exceptions_i ( flu_exception_ex_id       ),
+    .l1_icache_access_i  ( icache_dreq_if_cache      ),
+    .l1_dcache_access_i  ( dcache_req_ports_ex_cache ),
+    .miss_vld_bits_i     ( miss_vld_bits             ),
+    .i_tlb_flush_i       ( flush_tlb_ctrl_ex         ),
+    .stall_issue_i       ( stall_issue               )
   );
  end
 
@@ -916,15 +897,6 @@ module cva6 import ariane_pkg::*; #(
     .amo_req_i             ( amo_req                     ),
     .amo_resp_o            ( amo_resp                    ),
     .dcache_miss_o         ( dcache_miss_cache_perf      ),
-    .dcache_hit_o          ( dcache_hit_cache_perf       ),
-    .dcache_flushing_o     ( dcache_flushing_cache_perf  ),
-
-    .dcache_write_hit_unique_o   ( dcache_write_hit_unique_cache_perf   ),
-    .dcache_write_hit_shared_o   ( dcache_write_hit_shared_cache_perf   ),
-    .dcache_write_miss_o         ( dcache_write_miss_cache_perf         ),
-    .dcache_clean_invalid_hit_o  ( dcache_clean_invalid_hit_cache_perf  ),
-    .dcache_clean_invalid_miss_o ( dcache_clean_invalid_miss_cache_perf ),
-
     // this is statically set to 1 as the std_cache does not have a wbuffer
     .wbuffer_empty_o       ( dcache_commit_wbuffer_empty ),
     // from PTW, Load Unit  and Store Unit

--- a/core/perf_counters.sv
+++ b/core/perf_counters.sv
@@ -30,14 +30,6 @@ module perf_counters import ariane_pkg::*; #(
   // from L1 caches
   input  logic                                    l1_icache_miss_i,
   input  logic                                    l1_dcache_miss_i,
-  input  logic                                    l1_dcache_hit_i,
-  input  logic                                    l1_dcache_flushing_i,
-  input  logic                                    l1_dcache_write_hit_unique_i,
-  input  logic                                    l1_dcache_write_hit_shared_i,
-  input  logic                                    l1_dcache_write_miss_i,
-  input  logic                                    l1_dcache_clean_invalid_hit_i,
-  input  logic                                    l1_dcache_clean_invalid_miss_i,
-  input  logic                                    amo_i,
   // from MMU
   input  logic                                    itlb_miss_i,
   input  logic                                    dtlb_miss_i,
@@ -58,22 +50,18 @@ module perf_counters import ariane_pkg::*; #(
   input  logic                                    stall_issue_i  //stall-read operands
 );
 
-  logic [63:0] generic_counter_d[11:1];
-  logic [63:0] generic_counter_q[11:1];
-
-  logic l1_dcache_flushing_q;
-  logic amo_q;
+  logic [63:0] generic_counter_d[6:1];
+  logic [63:0] generic_counter_q[6:1];
 
   //internal signal to keep track of exception
   logic read_access_exception,update_access_exception;
 
-  logic events[11:1];
+  logic events[6:1];
   //internal signal for  MUX select line input
   logic [4:0] mhpmevent_d[6:1];
   logic [4:0] mhpmevent_q[6:1];
 
   //Multiplexer
-  /*
    always_comb begin : Mux
         events[6:1]='{default:0};
 
@@ -104,41 +92,27 @@ module perf_counters import ariane_pkg::*; #(
            5'b10100 : for (int unsigned j = 0; j < NR_COMMIT_PORTS; j++) if (commit_ack_i[j]) events[i] = commit_instr_i[j].fu == ALU || commit_instr_i[j].fu == MULT;//Integer instructions
            5'b10101 : for (int unsigned j = 0; j < NR_COMMIT_PORTS; j++) if (commit_ack_i[j]) events[i] = commit_instr_i[j].fu == FPU || commit_instr_i[j].fu == FPU_VEC;//Floating Point Instructions
            5'b10110 : events[i] = stall_issue_i;//Pipeline bubbles
-           5'b10111 : events[i] = l1_dcache_hit_i;
-           5'b11000 : events[i] = l1_dcache_flushing_i;
            default:   events[i] = 0;
          endcase
        end
-    end
-    */
 
-    assign events[1] = l1_dcache_miss_i;
-    assign events[2] = l1_dcache_hit_i;
-    assign events[3] = l1_dcache_flushing_i;
-    assign events[4] = l1_dcache_flushing_q & (!l1_dcache_flushing_i);
-    assign events[5] = amo_q & (!amo_i);
-    assign events[6] = 1'b1;
-    assign events[7] = l1_dcache_write_hit_unique_i;
-    assign events[8] = l1_dcache_write_hit_shared_i;
-    assign events[9] = l1_dcache_write_miss_i;
-    assign events[10] = l1_dcache_clean_invalid_hit_i;
-    assign events[11] = l1_dcache_clean_invalid_miss_i;
+    end
 
     always_comb begin : generic_counter
         generic_counter_d = generic_counter_q;
         data_o = 'b0;
         mhpmevent_d = mhpmevent_q;
-        read_access_exception =  1'b0;
-        update_access_exception =  1'b0;
+	    read_access_exception =  1'b0;
+	    update_access_exception =  1'b0;
 
-      for(int unsigned i = 1; i <= 11; i++) begin
-         if ((debug_mode_i == 1'b0) && (we_i == 1'b0)) begin
-             if (events[i] == 1'b1) begin
-                generic_counter_d[i] = generic_counter_q[i] + 1'b1; end
-         end else begin
-                generic_counter_d[i] = 'b0;
-         end
+      for(int unsigned i = 1; i <= 6; i++) begin
+         if ((!debug_mode_i) && (!we_i)) begin
+             if (events[i] == 1)begin
+                generic_counter_d[i] = generic_counter_q[i] + 1'b1;end
+            else begin
+                generic_counter_d[i] = 'b0;end
         end
+      end
 
      //Read
          unique case (addr_i)
@@ -160,35 +134,6 @@ module perf_counters import ariane_pkg::*; #(
             riscv::CSR_MHPM_EVENT_6,
             riscv::CSR_MHPM_EVENT_7,
             riscv::CSR_MHPM_EVENT_8   : data_o = mhpmevent_q[addr_i-riscv::CSR_MHPM_EVENT_3 + 1] ;
-            riscv::CSR_L1_ICACHE_MISS,
-            riscv::CSR_L1_DCACHE_MISS,
-            riscv::CSR_ITLB_MISS,
-            riscv::CSR_DTLB_MISS,
-            riscv::CSR_LOAD,
-            riscv::CSR_STORE,
-            riscv::CSR_EXCEPTION,
-            riscv::CSR_EXCEPTION_RET,
-            riscv::CSR_BRANCH_JUMP,
-            riscv::CSR_CALL,
-            riscv::CSR_RET,
-            riscv::CSR_MIS_PREDICT,
-            riscv::CSR_SB_FULL,
-            riscv::CSR_IF_EMPTY,
-            riscv::CSR_HPM_COUNTER_17,
-            riscv::CSR_HPM_COUNTER_18,
-            riscv::CSR_HPM_COUNTER_19,
-            riscv::CSR_HPM_COUNTER_20,
-            riscv::CSR_HPM_COUNTER_21,
-            riscv::CSR_HPM_COUNTER_22,
-            riscv::CSR_HPM_COUNTER_23,
-            riscv::CSR_HPM_COUNTER_24,
-            riscv::CSR_HPM_COUNTER_25,
-            riscv::CSR_HPM_COUNTER_26,
-            riscv::CSR_HPM_COUNTER_27,
-            riscv::CSR_HPM_COUNTER_28,
-            riscv::CSR_HPM_COUNTER_29,
-            riscv::CSR_HPM_COUNTER_30,
-            riscv::CSR_HPM_COUNTER_31 : data_o = generic_counter_q[addr_i-riscv::CSR_L1_ICACHE_MISS + 1];
             default: data_o = 'b0;
         endcase
 
@@ -223,31 +168,10 @@ module perf_counters import ariane_pkg::*; #(
         if (!rst_ni) begin
             generic_counter_q <= '{default:0};
             mhpmevent_q       <= '{default:0};
-            l1_dcache_flushing_q <= 1'b0;
-            amo_q <= 1'b0;
         end else begin
             generic_counter_q <= generic_counter_d;
             mhpmevent_q       <= mhpmevent_d;
-            l1_dcache_flushing_q <= l1_dcache_flushing_i;
-            amo_q <= amo_i;
        end
    end
-
-   xlnx_ila i_ila (
-    clk_i, 
-    generic_counter_q[1][63:32], 
-    generic_counter_q[1][31:0], 
-    generic_counter_q[2][63:32], 
-    generic_counter_q[2][31:0], 
-    generic_counter_q[3][63:32], 
-    generic_counter_q[3][31:0], 
-    generic_counter_q[4][63:32], 
-    generic_counter_q[4][31:0], 
-    {debug_mode_i, we_i, l1_dcache_miss_i, l1_dcache_hit_i, l1_dcache_flushing_i},
-    '0,
-    '0,
-    '0,
-    '0
-  );
 
 endmodule


### PR DESCRIPTION
 - revert modifications of csr_regfile and perf_counters.

 - remove most added debug/statistics signals from miss_handler and snoop_cache_ctrl.